### PR TITLE
FIx for [ERR_OUT_OF_RANGE]: The value of "byteLength" is out of range…

### DIFF
--- a/src/daap/Decoder.js
+++ b/src/daap/Decoder.js
@@ -872,7 +872,7 @@ function _decodeList(buffer, start, end) {
         } else if (type.type === 'int') {
           value = buffer.readUInt32BE(index + 8);
         } else if (type.type === 'long') {
-          value = buffer.readIntBE(index + 8, 8);
+          value = buffer.readUInt32BE(index + 8);
         } else if (type.type === 'list') {
           value = _decodeList(buffer, index + 8, index + 8 + length);
         } else if (type.type === 'struct') {
@@ -924,7 +924,7 @@ function _decode(buffer, start, end) {
         } else if (type.type === 'int') {
           value = buffer.readUInt32BE(index + 8);
         } else if (type.type === 'long') {
-          value = buffer.readIntBE(index + 8, 8);
+          value = buffer.readUInt32BE(index + 8);
         } else if (type.type === 'ulong') {
           value = buffer.readUIntBE(index + 8, 8);
         } else if (type.type === 'list') {


### PR DESCRIPTION
Change conversion of long to integer from using buffer.readIntBE to buffer.readUInt32BE as node.js since version 10.0 checks that paramter byteLength in buffer.readIntBE is less than 6. One can argue that this should use buffer.readBigInt64BE but that is only available in node.js 12.0